### PR TITLE
Update gamepad remapping for PS controllers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.idea/
+.DS_Store

--- a/patches/gamepad-remapping/cs/GameInput__GetKeyCodeForControllerLayout.cs
+++ b/patches/gamepad-remapping/cs/GameInput__GetKeyCodeForControllerLayout.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using Gendarme;
+using UnityEngine;
+
+// Token: 0x020003D2 RID: 978
+public partial class GameInput : MonoBehaviour
+{
+	// Token: 0x0600193F RID: 6463 RVA: 0x000A80A0 File Offset: 0x000A62A0
+	private KeyCode GetKeyCodeForControllerLayout(KeyCode keyCode, GameInput.ControllerLayout controllerLayout)
+	{
+		if (controllerLayout == GameInput.ControllerLayout.PS4 || controllerLayout == GameInput.ControllerLayout.PS5)
+		{
+			if (keyCode >= KeyCode.JoystickButton0 && keyCode <= KeyCode.Joystick8Button19)
+			{
+				switch (keyCode)
+				{
+				case KeyCode.JoystickButton3:
+					return KeyCode.JoystickButton0;
+				case KeyCode.JoystickButton4:
+					return KeyCode.JoystickButton3;
+				case KeyCode.JoystickButton5:
+					return KeyCode.JoystickButton4;
+				case KeyCode.JoystickButton6:
+					return KeyCode.JoystickButton5;
+				case KeyCode.JoystickButton7:
+					return KeyCode.JoystickButton13;
+				case KeyCode.JoystickButton8:
+					return KeyCode.JoystickButton9;
+				case KeyCode.JoystickButton9:
+					return KeyCode.JoystickButton10;
+				case KeyCode.JoystickButton10:
+					return KeyCode.JoystickButton11;
+				case KeyCode.JoystickButton11:
+					return KeyCode.JoystickButton8;
+				}
+			}
+			return keyCode;
+		}
+		return keyCode;
+	}
+}

--- a/patches/gamepad-remapping/cs/GameInput__UpdateAxisValues.cs
+++ b/patches/gamepad-remapping/cs/GameInput__UpdateAxisValues.cs
@@ -81,11 +81,11 @@ public partial class GameInput : MonoBehaviour
 					vector2.x = UnityEngine.Input.GetAxis("ControllerAxis1");
 					vector2.y = UnityEngine.Input.GetAxis("ControllerAxis2");
 					vector4.x = UnityEngine.Input.GetAxis("ControllerAxis3");
-					vector4.y = UnityEngine.Input.GetAxis("ControllerAxis6");
-					num = UnityEngine.Input.GetAxis("ControllerAxis4") * 0.5f + 0.5f;
-					num2 = UnityEngine.Input.GetAxis("ControllerAxis5") * 0.5f + 0.5f;
+					vector4.y = UnityEngine.Input.GetAxis("ControllerAxis4");
+					num = UnityEngine.Input.GetAxis("ControllerAxis5");
+					num2 = UnityEngine.Input.GetAxis("ControllerAxis6");
 					num3 = UnityEngine.Input.GetAxis("ControllerAxis7");
-					num4 = UnityEngine.Input.GetAxis("ControllerAxis8");
+					num4 = -UnityEngine.Input.GetAxis("ControllerAxis8");
 					break;
 				case GameInput.ControllerLayout.Switch:
 					vector2.x = InputUtils.GetAxis("ControllerAxis1");
@@ -111,11 +111,11 @@ public partial class GameInput : MonoBehaviour
 					vector2.x = UnityEngine.Input.GetAxis("ControllerAxis1");
 					vector2.y = UnityEngine.Input.GetAxis("ControllerAxis2");
 					vector4.x = UnityEngine.Input.GetAxis("ControllerAxis3");
-					vector4.y = UnityEngine.Input.GetAxis("ControllerAxis6");
-					num = UnityEngine.Input.GetAxis("ControllerAxis4") * 0.5f + 0.5f;
-					num2 = UnityEngine.Input.GetAxis("ControllerAxis5") * 0.5f + 0.5f;
+					vector4.y = UnityEngine.Input.GetAxis("ControllerAxis4");
+					num = UnityEngine.Input.GetAxis("ControllerAxis5");
+					num2 = UnityEngine.Input.GetAxis("ControllerAxis6");
 					num3 = UnityEngine.Input.GetAxis("ControllerAxis7");
-					num4 = UnityEngine.Input.GetAxis("ControllerAxis8");
+					num4 = -UnityEngine.Input.GetAxis("ControllerAxis8");
 					break;
 				default:
 					throw new NotImplementedException(string.Format("{0} ControllerLayout support is not implemented!", controllerLayout));


### PR DESCRIPTION
Following the issue #4

Updated gamepad remappings which were defined initially in `GameInput.GetKeyCodeForControllerLayout` specifically for PS4 and PS5 controllers. The factory remappings were all over the place, so I tested each one of them on my PS5 controller. This should work for PS4 as well, but I didn't test so cannot guarantee it.

All buttons are now correctly identified by the game, including the touch pad (as a button). Since the touch pad is used for the PDA in the default game's bindings, the "Create" button is not in use by the default and can be mapped as Button 11 to anything else in settings. The PS button is Button 12.

Additionally, I fixed the axis for these two controllers.

Didn't supply/update the `.il` files because I used dnSpy and C# for the first time yesterday, and Assembly is well beyond my general programming knowledge.